### PR TITLE
Set the isAdmin column to default to false

### DIFF
--- a/src/main/java/com/benchwarmers/grads/grizzlystoreuser/entities/Account.java
+++ b/src/main/java/com/benchwarmers/grads/grizzlystoreuser/entities/Account.java
@@ -31,7 +31,7 @@ public class Account {
     private String accountPassword;
 
     @Column(name = "account_IsAdmin", nullable = false)
-    private boolean accountIsAdmin;
+    private boolean accountIsAdmin = false;
 
     @CreationTimestamp
     @Column(name = "DateTime", nullable = false)


### PR DESCRIPTION
The isAdmin column in the Account entity didn't have a default value but now it defaults to false.