### PR TITLE
Issue with creating symbolic links (too many levels)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -12,5 +12,5 @@ if [ -f grizzlystore-user ] ; then
     sudo rm /etc/init.d/grizzlystore-user || true
 fi
 
-sudo ln -s *.jar /etc/init.d/grizzlystore-user
+cp *.jar /opt/GrizzlyStoreMicroServices/GrizzlyStore-User.jar
 sudo systemctl start grizzlystore-user.service


### PR DESCRIPTION
Rather than creating a symbol link, I am now copying the jar file to a separate location then running it as a service